### PR TITLE
only "lib" is kept from play dist

### DIFF
--- a/assembly-desktop.xml
+++ b/assembly-desktop.xml
@@ -12,12 +12,8 @@
             <outputDirectory>/</outputDirectory>
         </fileSet>
         <fileSet>
-            <directory>target/pipeline2-webui</directory>
-            <excludes>
-                <exclude>start</exclude>
-                <exclude>start.bat</exclude>
-            </excludes>
-            <outputDirectory>/daisy-pipeline/webui</outputDirectory>
+            <directory>target/pipeline2-webui/lib</directory>
+            <outputDirectory>/daisy-pipeline/webui/lib</outputDirectory>
         </fileSet>
         
         <fileSet>

--- a/assembly-server.xml
+++ b/assembly-server.xml
@@ -8,12 +8,8 @@
     <baseDirectory>daisy-pipeline-webui</baseDirectory>
     <fileSets>
         <fileSet>
-            <directory>target/pipeline2-webui</directory>
-            <excludes>
-                <exclude>start</exclude>
-                <exclude>start.bat</exclude>
-            </excludes>
-            <outputDirectory>/</outputDirectory>
+            <directory>target/pipeline2-webui/lib</directory>
+            <outputDirectory>/lib/</outputDirectory>
         </fileSet>
         
         <fileSet>


### PR DESCRIPTION
should prevent the assembly from being included in the final package
