### PR TITLE
improvements and bugfixes for downloading files

### DIFF
--- a/server/app/controllers/Application.java
+++ b/server/app/controllers/Application.java
@@ -20,8 +20,7 @@ public class Application extends Controller {
 	
 	public static final boolean debug = "DEBUG".equals(Configuration.root().getString("logger.application"));
 	
-	public static final String DEFAULT_DP2_ENDPOINT_LOCAL = "http://localhost:8181/ws";
-	public static final String DEFAULT_DP2_ENDPOINT_REMOTE = "http://localhost:8182/ws";
+	public static final String DEFAULT_DP2_ENDPOINT = "http://localhost:8181/ws";
 	public static final String SLASH = System.getProperty("file.separator");
 	public static final String SYSTEM_TEMP;
 	public static final String DP2TEMP;

--- a/server/app/controllers/FirstUse.java
+++ b/server/app/controllers/FirstUse.java
@@ -239,7 +239,7 @@ public class FirstUse extends Controller {
 		
 		Setting.set("uploads", uploads);
 		
-		Setting.set("dp2ws.endpoint", controllers.Application.DEFAULT_DP2_ENDPOINT_LOCAL);
+		Setting.set("dp2ws.endpoint", controllers.Application.DEFAULT_DP2_ENDPOINT);
 		Setting.set("dp2ws.authid", "");
 		Setting.set("dp2ws.secret", "");
 	}

--- a/server/app/views/Administrator/Forms/userAdd.scala.html
+++ b/server/app/views/Administrator/Forms/userAdd.scala.html
@@ -71,7 +71,9 @@
 			@if(Setting.get("mail.enable") == "false") {
 				<div class="form-actions">
 					<button class="btn btn-primary" id="createUser-submit" type="submit" name="submit" disabled="">Create user</button>
-					<span class="help-inline">An e-mail will be sent to the user with a link to a page where the user can set up their password.</span>
+					@if(Setting.get("mail.enable") == "true") {
+						<span class="help-inline">An e-mail will be sent to the user with a link to a page where the user can set up their password.</span>
+					}
 				</div>
 			}
 			

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -3,12 +3,12 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
+  <!--<parent>
     <groupId>org.daisy</groupId>
     <artifactId>daisy</artifactId>
     <version>2</version>
     <relativePath />
-  </parent>
+  </parent>-->
 
   <groupId>org.daisy.pipeline</groupId>
   <artifactId>webui</artifactId>
@@ -100,7 +100,7 @@
     <dependency>
         <groupId>org.daisy.pipeline</groupId>
         <artifactId>clientlib-java</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </dependency>
     
     <dependency>

--- a/server/project/Build.scala
+++ b/server/project/Build.scala
@@ -19,7 +19,7 @@ object ApplicationBuild extends Build {
       // project dependencies (remember to also update pom.xml!)
       "org.apache.derby" % "derby" % "10.9.1.0",
       "mysql" % "mysql-connector-java" % "5.1.18",
-      "org.daisy.pipeline" % "clientlib-java" % "1.0.0",
+      "org.daisy.pipeline" % "clientlib-java" % "1.1.0-SNAPSHOT",
       "org.apache.commons" % "commons-compress" % "1.4.1",
       "org.apache.commons" % "commons-email" % "1.2",
       "log4j" % "log4j" % "1.2.17",
@@ -29,8 +29,7 @@ object ApplicationBuild extends Build {
     val main = play.Project(appName, appVersion, appDependencies).settings(
       // project settings
       ebeanEnabled := true,
-      resolvers += ("Local Maven Repository" at "file:///"+Path.userHome.absolutePath+"/.m2/repository"),
-      resolvers += ("Public online Restlet repository" at "http://maven.restlet.org")
+      resolvers += ("Local Maven Repository" at "file:///"+Path.userHome.absolutePath+"/.m2/repository")
     ).settings(
       javacOptions ++= Seq("-source", "1.6", "-target", "1.6")
     )


### PR DESCRIPTION
depends on clientlib-java v1.1.0; see daisy/pipeline-clientlib-java#1
- fixed issue where the selected tab in admin settings were seemingly random each time you updated the page
- no more references to port 8182, 8181 is the only default from now on
- the webui is now required to run on the same filesystem as the engine. Results are downloaded directly from disk. fixes daisy/pipeline-issues#375
- the correct content type is now returned when downloading single files
- "an e-mail will be sent to user ..." in create user form now only shows when email is enabled
- filenames are improved for downloads. fixes daisy/pipeline-issues#385
- this seems to fix daisy/pipeline-issues#381 as well, although the issue haven't been adressed specifically
