### PR TITLE
enable/disable scripts for all users. filter own/all jobs.

### DIFF
--- a/server/app/controllers/Jobs.java
+++ b/server/app/controllers/Jobs.java
@@ -66,6 +66,7 @@ public class Jobs extends Controller {
 		
 		if (user.admin)
 			flash("showOwner", "true");
+		flash("userid", user.id+"");
 		
 		User.flashBrowserId(user);
 		return ok(views.html.Jobs.getJobs.render());

--- a/server/app/controllers/Scripts.java
+++ b/server/app/controllers/Scripts.java
@@ -47,7 +47,7 @@ public class Scripts extends Controller {
 				scripts = new ArrayList<Script>();
 				List<Script> allScripts = Script.getScripts(response);
 				for (Script script : allScripts) {
-					if (!"false".equals(UserSetting.get(user.id, "scriptEnabled-"+script.id))) {
+					if (!"false".equals(UserSetting.get(-2L, "scriptEnabled-"+script.id)) || user.admin && request().queryString().containsKey("showAll")) {
 						scripts.add(script);
 					}
 				}
@@ -74,7 +74,7 @@ public class Scripts extends Controller {
 		if (user == null)
 			return redirect(routes.Login.login());
 		
-		if ("false".equals(UserSetting.get(user.id, "scriptEnabled-"+id))) {
+		if ("false".equals(UserSetting.get(-2L, "scriptEnabled-"+id))) {
 			return forbidden();
 		}
 		
@@ -142,7 +142,7 @@ public class Scripts extends Controller {
 		if (user == null)
 			return unauthorized("unauthorized");
 		
-		if ("false".equals(UserSetting.get(user.id, "scriptEnabled-"+id))) {
+		if ("false".equals(UserSetting.get(-2L, "scriptEnabled-"+id))) {
 			return forbidden();
 		}
 		

--- a/server/app/views/Administrator/Forms/configureScripts.scala.html
+++ b/server/app/views/Administrator/Forms/configureScripts.scala.html
@@ -1,0 +1,65 @@
+@(scriptsForm: Form[controllers.Administrator.ConfigureScripts], route: play.api.mvc.Call)
+
+@helper.form(action = route) {
+	
+	<input type="hidden" name="formName" value="configureScripts"/>
+	
+	<fieldset>
+		<legend>Scripts</legend>
+        <br/>
+        
+        <div class="form-horizontal">
+        	
+			<div class="control-group @("error".when(scriptsForm.error("scriptPermissions") != null))">
+				<div class="controls">
+					<span id="configureScripts-loadingScripts" class="help-block">Loading scripts...</span>
+					@if(scriptsForm.field("scriptPermissions").errors().size() > 0){
+						<span class="help-block">@scriptsForm.error("scriptPermissions").message</span>
+					}
+				</div>
+			</div>
+			<script type="text/javascript">
+				$(function(){
+					var scriptPermissions = @Html(play.libs.Json.stringify(play.libs.Json.toJson(controllers.Administrator.ConfigureScripts.scriptPermissions())));
+					var scriptHrefBase = "@routes.Scripts.getScript("")";
+					var checkForScripts = function() {
+						$.ajax({
+							url: "@routes.Scripts.getScriptsJson()?showAll",
+							error: function(jqXHR, textStatus, errorThrown) {
+								setTimeout(checkForScripts,5000);
+							},
+							success: function(scripts, textStatus, jqXHR) {
+								var s;
+								$("#configureScripts-loadingScripts").hide();
+								for (s = 0; s < scripts.length; s++) {
+									var div;
+									var enabled = scriptPermissions[scripts[s].id];
+									div = $("<div class=\"control-group\"></div>");
+									$(div).append("<label class=\"control-label\" id=\"configureScripts-script-"+scripts[s].id+"-label\">"+scripts[s].nicename+"</label>");
+									$(div).append("<div class=\"controls\"></div>");
+									$(div).find(".controls").append("<div class=\"btn-group\" data-toggle=\"buttons-radio\" aria-role=\"radiogroup\" aria-labelledby=\"configureScripts-script-"+scripts[s].id+"-label\" id=\"configureScripts-script-"+scripts[s].id+"\"></div>");
+									$(div).find(".btn-group").append("<button type=\"button\" name=\"configureScripts-script-"+scripts[s].id+"-off\" class=\"btn "+(enabled?"":"active")+"\" id=\"configureScripts-script-"+scripts[s].id+"-disable\" aria-role=\"radio\" aria-checked=\""+(enabled?"false":"true")+"\" onclick=\"toggleRadio('configureScripts-script-"+scripts[s].id+"', false, '"+enabled+"');\">Disable</button>");
+									$(div).find(".btn-group").append("<button type=\"button\" name=\"configureScripts-script-"+scripts[s].id+"-on\" class=\"btn "+(enabled?"active":"")+"\" id=\"configureScripts-script-"+scripts[s].id+"-enable\" aria-role=\"radio\" aria-checked=\""+(enabled?"true":"false")+"\" onclick=\"toggleRadio('configureScripts-script-"+scripts[s].id+"', true, '"+enabled+"');\">Enable</button>");
+									$(div).find(".btn-group").append("<input type=\"hidden\" id=\"configureScripts-script-"+scripts[s].id+"-value\" name=\"configureScripts-script-"+scripts[s].id+"\" value=\""+enabled+"\"/>");
+									$("#configureScripts-submitButtons").before(div);
+								}
+								
+							}
+						});
+					}
+					
+					if (typeof scriptPermissions === "string") {
+						$("#configureScripts-loadingScripts").html(scriptPermissions);
+					} else {
+						checkForScripts();
+					}
+				});
+			</script>
+			
+			<div class="form-actions" id="configureScripts-submitButtons">
+				<button type="submit" class="btn btn-primary" id="configureScripts-submit" name="submit">Save</button>
+			</div>
+			
+		</div>
+	</fieldset>
+}

--- a/server/app/views/Administrator/Forms/userGuest.scala.html
+++ b/server/app/views/Administrator/Forms/userGuest.scala.html
@@ -27,53 +27,6 @@
 	            </div>
 			</div>
 			
-			<div class="control-group @("error".when(guestForm.error("scriptPermissions") != null))">
-				<h3>Script permissions:</h3>
-				<div class="controls">
-					<span id="user-users-guest-loadingScripts" class="help-block">Loading scripts...</span>
-					@if(guestForm.field("scriptPermissions").errors().size() > 0){
-						<span class="help-block">@guestForm.error("scriptPermissions").message</span>
-					}
-				</div>
-			</div>
-			<script type="text/javascript">
-				$(function(){
-					var scriptPermissions = @Html(play.libs.Json.stringify(play.libs.Json.toJson(controllers.Administrator.GuestUser.scriptPermissions())));
-					var scriptHrefBase = "@routes.Scripts.getScript("")";
-					var checkForScripts = function() {
-						$.ajax({
-							url: "@routes.Scripts.getScriptsJson()",
-							error: function(jqXHR, textStatus, errorThrown) {
-								setTimeout(checkForScripts,5000);
-							},
-							success: function(scripts, textStatus, jqXHR) {
-								var s;
-								$("#user-users-guest-loadingScripts").hide();
-								for (s = 0; s < scripts.length; s++) {
-									var div;
-									var enabled = scriptPermissions[scripts[s].id];
-									div = $("<div class=\"control-group\"></div>");
-									$(div).append("<label class=\"control-label\" id=\"user-users-guest-script-"+scripts[s].id+"-label\">"+scripts[s].nicename+"</label>");
-									$(div).append("<div class=\"controls\"></div>");
-									$(div).find(".controls").append("<div class=\"btn-group\" data-toggle=\"buttons-radio\" aria-role=\"radiogroup\" aria-labelledby=\"user-users-guest-script-"+scripts[s].id+"-label\" id=\"user-users-guest-script-"+scripts[s].id+"\"></div>");
-									$(div).find(".btn-group").append("<button type=\"button\" name=\"user-users-guest-script-"+scripts[s].id+"-off\" class=\"btn "+(enabled?"":"active")+"\" id=\"user-users-guest-script-"+scripts[s].id+"-disable\" aria-role=\"radio\" aria-checked=\""+(enabled?"false":"true")+"\" onclick=\"toggleRadio('user-users-guest-script-"+scripts[s].id+"', false, '"+enabled+"');\">Disable</button>");
-									$(div).find(".btn-group").append("<button type=\"button\" name=\"user-users-guest-script-"+scripts[s].id+"-on\" class=\"btn "+(enabled?"active":"")+"\" id=\"user-users-guest-script-"+scripts[s].id+"-enable\" aria-role=\"radio\" aria-checked=\""+(enabled?"true":"false")+"\" onclick=\"toggleRadio('user-users-guest-script-"+scripts[s].id+"', true, '"+enabled+"');\">Enable</button>");
-									$(div).find(".btn-group").append("<input type=\"hidden\" id=\"user-users-guest-script-"+scripts[s].id+"-value\" name=\"user-users-guest-script-"+scripts[s].id+"\" value=\""+enabled+"\"/>");
-									$("#user-users-guest-submitButtons").before(div);
-								}
-								
-							}
-						});
-					}
-					
-					if (typeof scriptPermissions === "string") {
-						$("#user-users-guest-loadingScripts").html(scriptPermissions);
-					} else {
-						checkForScripts();
-					}
-				});
-			</script>
-			
 			<div class="form-actions" id="user-users-guest-submitButtons">
 				<button type="submit" class="btn btn-primary" id="user-guest-submit" name="submit">Save</button>
 				<!--<button type="reset" class="btn" id="user-guest-reset" name="reset" onclick="toggleChanged('user-users.guest.name', '@models.Setting.get("users.guest.name")', '@models.Setting.get("users.guest.name")');">Clear</button>-->

--- a/server/app/views/Administrator/settings.scala.html
+++ b/server/app/views/Administrator/settings.scala.html
@@ -40,6 +40,7 @@
 @if(controllers.Application.deployment()=="server"){
 <ul class="nav nav-pills">
     <li class="@("active".when(Controller.flash("settings.formName")==null||Controller.flash("settings.formName")=="updateGlobalPermissions"||Controller.flash("settings.formName")=="updateGuest"||Controller.flash("settings.formName")=="updateUser"||Controller.flash("settings.formName")=="deleteUser"||Controller.flash("settings.formName")=="createUser"))"><a href="#usersAndPermissions" data-toggle="tab">Users and Permissions</a></li>
+    <li class="@("active".when(Controller.flash("settings.formName")=="configureScripts"))"><a href="#configureScripts" data-toggle="tab">Scripts</a></li>
     <li class="@("active".when(Controller.flash("settings.formName")=="setWS"))"><a href="#pipeline2WebServiceEndpoint" data-toggle="tab">Pipeline 2 Web API</a></li>
     <li class="@("active".when(Controller.flash("settings.formName")=="setStorageDirs"))"><a href="#storageDirectories" data-toggle="tab">Storage directories</a></li>
     <li class="@("active".when(Controller.flash("settings.formName")=="configureEmail"))"><a href="#eMailSettings" data-toggle="tab">E-mail settings</a></li>
@@ -90,6 +91,12 @@
 				</div>
 			</div>
 		</div>
+	</section>
+	
+	<section id="configureScripts" class="tab-pane @("active".when(Controller.flash("settings.formName")=="configureScripts"))">
+		<h2>Scripts</h2>
+		<br/>
+		@views.html.Administrator.Forms.configureScripts(forms.scriptsForm, routes.Administrator.postSettings())
 	</section>
 	
 	<section id="pipeline2WebServiceEndpoint" class="tab-pane @("active".when(Controller.flash("settings.formName")=="setWS"))">

--- a/server/app/views/Jobs/getJobs.scala.html
+++ b/server/app/views/Jobs/getJobs.scala.html
@@ -5,7 +5,22 @@
 <hgroup>
 <h1>Jobs</h1>
 @if(session.get("admin")=="true"){
-	<p>Displaying jobs for all users</p>
+	<script>
+		filterJobs = function(user) {
+		    if (user === 'all') {
+				$("#joblist tbody tr").show();
+				$("#showYourJobs").removeClass("active");
+				$("#showAllJobs").addClass("active");
+			} else {
+				$("#joblist tbody tr[data-user='"+user+"']").show();
+				$("#joblist tbody tr[data-user!='"+user+"']").hide();
+				$("#showAllJobs").removeClass("active");
+				$("#showYourJobs").addClass("active");
+			}
+		}
+	</script>
+	<a id="showYourJobs" class="btn active" onclick="filterJobs(@Controller.flash("userid"));" href="javascript:void(0)">Your jobs</a>
+	<a id="showAllJobs" class="btn" onclick="filterJobs('all');" href="javascript:void(0)">All jobs</a>
 }else{
 @if(Setting.get("users.guest.shareJobs") == "true"){
 	<p>Displaying jobs for all guests</p>
@@ -32,10 +47,12 @@
 <script type="text/javascript">
 
 addJob = function(job) {
-	var i, statusText, html;
+	var i, statusText, html, visible;
 	statusText = job.status.charAt(0).toUpperCase() + job.status.slice(1).toLowerCase();
 	statusText = statusText.replace(/_/,' ');
-	html = '<tr id="job-'+job.id+'" class="job">'+"\n";
+	visible = $("#showAllJobs").hasClass("active") || "@Controller.flash("userid")" === ""+job.user;
+	console.log(visible, $("#showAllJobs").hasClass("active"),' || ',"@Controller.flash("userid")" === ""+job.user);
+	html = '<tr id="job-'+job.id+'" class="job" data-user="'+job.user+'"'+(!visible?' style="display:none;"':'')+'>'+"\n";
 	html += '    <td id="job-status-'+job.id+'">'+"\n";
 	html += '        <img src="@routes.Assets.at("images/")'+job.status+'.png" alt="'+statusText+'" title="'+statusText+'"/>'+"\n";
 	html += '    </td>'+"\n";


### PR DESCRIPTION
- Scripts are now enabled/disabled for all users, not only guests.
- The enable/disable scripts widget has been moved into its own admin settings tab.
- In the jobs list, admins now only view a list of their own jobs by default, but can click "show all jobs" to show jobs from other users as well.
