### PR TITLE
Improvements to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN mkdir data && mv db-empty data/db
 # then use the build artifacts to create an image where the pipeline is installed
 FROM openjdk:8-jre
 LABEL maintainer="DAISY Consortium (http://www.daisy.org/)"
-COPY --from=builder /usr/src/webui/target/docker/stage/opt/docker /opt/pipeline2-webui/.
+COPY --from=builder /usr/src/webui/target/docker/stage/opt/docker /opt/daisy-pipeline2-webui/.
 RUN mkdir /run/daisy-pipeline2-webui
 EXPOSE 9000 9443
-ENTRYPOINT ["/opt/pipeline2-webui/bin/pipeline2-webui"]
+ENTRYPOINT ["/opt/daisy-pipeline2-webui/bin/pipeline2-webui"]
 CMD []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - "9000:9000"
     volumes:
-      - "webui-data:/opt/pipeline2-webui/data"
+      - "webui-data:/opt/daisy-pipeline2-webui/data"
     depends_on:
       pipeline:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,10 @@ services:
   pipeline:
     image: daisyorg/pipeline-assembly
     environment:
-      PIPELINE2_WS_AUTHENTICATION: "false"
       PIPELINE2_WS_HOST: "pipeline"
+      PIPELINE2_WS_AUTHENTICATION: "false"
+    volumes:
+      - "pipeline-data:/opt/daisy-pipeline2/data"
   webui:
     image: daisyorg/pipeline-webui
     environment:
@@ -16,6 +18,6 @@ services:
     depends_on:
       pipeline:
         condition: service_healthy
-
 volumes:
+  pipeline-data:
   webui-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ services:
     image: daisyorg/pipeline-assembly
     environment:
       PIPELINE2_WS_AUTHENTICATION: "false"
-      PIPELINE2_WS_LOCALFS: "false"
       PIPELINE2_WS_HOST: "pipeline"
   webui:
     image: daisyorg/pipeline-webui

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "2.1"
 services:
   pipeline:
-    image: daisyorg/pipeline2
+    image: daisyorg/pipeline-assembly
     environment:
       PIPELINE2_WS_AUTHENTICATION: "false"
       PIPELINE2_WS_LOCALFS: "false"
       PIPELINE2_WS_HOST: "pipeline"
   webui:
-    image: daisyorg/webui
+    image: daisyorg/pipeline-webui
     environment:
       DAISY_PIPELINE2_URL: http://pipeline:8181/ws
     ports:


### PR DESCRIPTION
Here's a few improvements to the Docker image and the docker-compose file

### Docker image
1. Install the webui in a standard location inside the image

### Compose file
1. Use the image names from Docker hub, so that automatic pulling from hub works
2. Remove an environment variable which is set by default anyway
3. Add a volume for the pipeline data, so that old jobs aren't lost on restart