### PR TITLE
Bugfixes in regex field validation

### DIFF
--- a/app/views/Jobs/Widgets/string.scala.html
+++ b/app/views/Jobs/Widgets/string.scala.html
@@ -9,7 +9,7 @@
 		<div class="controls">
 			<input name="@{arg.getName()}" id="text-@scriptId-@{arg.getName()}" type="text" @if(arg.getDefaultValue() != null){ value="@arg.getDefaultValue().replaceAll("\"","'")" }
 				@if(Scripts.chooseWidget(arg)=="regex"){
-					pattern="@{Application.ws.getDataType(arg.getDataType()).asInstanceOf[org.daisy.pipeline.client.models.datatypes.RegexType].regex.replaceAll("\"","&quot;")}"
+					pattern="@{Application.ws.getDataType(arg.getDataType()).asInstanceOf[org.daisy.pipeline.client.models.datatypes.RegexType].regex}"
 				}
 			/>
 			@Helpers.ArgumentDescription(arg, scriptId)
@@ -20,8 +20,16 @@
 	$(function(){
 		@if(Scripts.chooseWidget(arg)=="regex"){
 			var regexMessage = '@Html(Application.ws.getDataType(arg.getDataType()).asInstanceOf[org.daisy.pipeline.client.models.datatypes.RegexType].getDescription().replace("\\","\\\\").replace("\n","\\n").replace("\"","\\\"").replace("'","\\'").replace("/","\\/"))';
-			$("#text-@scriptId-@{arg.getName()}").attr("oninvalid", function(){ $("#text-@scriptId-@{arg.getName()}")[0].setCustomValidity(regexMessage); } );
-			$("#text-@scriptId-@{arg.getName()}").attr("oninput", function(){ $("#text-@scriptId-@{arg.getName()}")[0].setCustomValidity(regexMessage); } );
+			var inputElem = $("#text-@scriptId-@{arg.getName()}");
+			var regex = new RegExp(inputElem.attr("pattern"));
+			inputElem.on("input", function() {
+				inputElem[0].setCustomValidity(regex.test(inputElem[0].value) ? "" : regexMessage);
+			});
+			inputElem.on("invalid", function() {
+				// called on form submission
+				// this should have been covered already by oninput:
+				inputElem[0].setCustomValidity(regexMessage);
+			});
 		}
 		Job.setFromTemplateHandlers.push(function(arg, uploads) {
 			if (arg.name === "@arg.getName()") {

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ import com.typesafe.sbt.packager.windows.WixHelper
 
 organization := "org.daisy.pipeline"
 name := "webui"
-version := "2.6.1"
+version := "2.6.2-SNAPSHOT"
 
 organizationName := "The DAISY Consortium"
 organizationHomepage := Some(url("http://daisy.org"))


### PR DESCRIPTION
- .attr("oninput", ...) and .attr("oninvalid", ...) did not work as expected. Replaced by .on("input", ...) and .on("invalid", ...).
- On "input" events the current value needs to be matched against the pattern.
- Escaping " to &quot; is not needed. This is done by the Scala template system.

Make a bugfix release of this change and merge with master afterwards.
